### PR TITLE
Add Typescript default export compatibily

### DIFF
--- a/src/Cluster/Cluster.ts
+++ b/src/Cluster/Cluster.ts
@@ -91,7 +91,8 @@ export class Cluster extends EventEmitter {
 	}
 
 	public static _run(manager: ShardingManager) {
-		const ClusterClass = require(manager.path);
+		const ClusterClassRequire = require(manager.path);
+		const ClusterClass = ClusterClassRequire.default ? ClusterClassRequire.default : ClusterClassRequire;
 		const cluster: BaseCluster = new ClusterClass(manager);
 		cluster.init();
 	}


### PR DESCRIPTION
Seeing as typescript has a default export type and this can error out as it is exported as exports.default and not module.exports I decided to just PR this one line.